### PR TITLE
Add static placeholder pages for game links

### DIFF
--- a/games/animal-box/index.html
+++ b/games/animal-box/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Animal Box | Abe's Spelling Fun</title>
+    <link rel="stylesheet" href="../../static-page.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Animal Box</h1>
+        <p>Match adorable animals with the sounds they make and expand your budding reader's vocabulary.</p>
+      </header>
+
+      <section>
+        <p>
+          This mini-game is part of the Abe's Spelling Fun collection. When the full web app is ready, this
+          page will launch the interactive Phaser experience where kids drag animals into the correct sound box.
+        </p>
+        <p>
+          Until then, you can explore the project roadmap and assets in the repository while the engineering
+          team brings everything together for the public release.
+        </p>
+      </section>
+
+      <section>
+        <ul class="feature-list">
+          <li>Drag-and-drop gameplay that reinforces letter-sound relationships.</li>
+          <li>Gentle encouragement and cheerful effects to celebrate correct matches.</li>
+          <li>Built with accessibility in mind for young learners.</li>
+        </ul>
+      </section>
+
+      <a class="button" href="../../index.html">Back to game selection</a>
+    </main>
+  </body>
+</html>

--- a/games/basketball/index.html
+++ b/games/basketball/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Basketball Spelling | Abe's Spelling Fun</title>
+    <link rel="stylesheet" href="../../static-page.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Basketball Spelling</h1>
+        <p>Sink shots by spelling every challenge word correctly before the buzzer runs out.</p>
+      </header>
+
+      <section>
+        <p>
+          We are still polishing the hoops-inspired spelling challenge. When the production build ships, this
+          page will launch the real-time game complete with announcer call-outs and celebratory effects.
+        </p>
+        <p>
+          Follow the repository for behind-the-scenes updates and keep an eye out for open play-testing calls.
+        </p>
+      </section>
+
+      <section>
+        <ul class="feature-list">
+          <li>Timed spelling drills that reward accuracy and speed.</li>
+          <li>Power-ups that help players when they need a quick hint.</li>
+          <li>Encouraging commentary to keep learners motivated.</li>
+        </ul>
+      </section>
+
+      <a class="button" href="../../index.html">Back to game selection</a>
+    </main>
+  </body>
+</html>

--- a/games/block-breaker/index.html
+++ b/games/block-breaker/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Block Breaker | Abe's Spelling Fun</title>
+    <link rel="stylesheet" href="../../static-page.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Block Breaker</h1>
+        <p>Coming soon! Sharpen reflexes while spelling target words to clear every block from the board.</p>
+      </header>
+
+      <section>
+        <p>
+          Block Breaker is in the concept stage. We are prototyping game feel, level pacing, and the best way to
+          weave spelling practice into an arcade-style experience.
+        </p>
+        <p>
+          Check back soon for development diaries and invitations to try the first playable build.
+        </p>
+      </section>
+
+      <section>
+        <ul class="feature-list">
+          <li>Breakout-inspired action controlled by typing each highlighted word.</li>
+          <li>Dynamic difficulty that keeps players engaged without frustration.</li>
+          <li>Mini-goals to celebrate every milestone on the way to mastery.</li>
+        </ul>
+      </section>
+
+      <a class="button" href="../../index.html">Back to game selection</a>
+    </main>
+  </body>
+</html>

--- a/games/block-builder/index.html
+++ b/games/block-builder/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Block Builder | Abe's Spelling Fun</title>
+    <link rel="stylesheet" href="../../static-page.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Block Builder</h1>
+        <p>Stack colorful letter blocks to build words and practice spelling patterns in a playful way.</p>
+      </header>
+
+      <section>
+        <p>
+          The interactive Block Builder experience is under construction. Once development wraps up, this page
+          will load the real game powered by our Phaser engine.
+        </p>
+        <p>
+          For now, you can review the latest progress in the repository and share ideas for new word lists or
+          visual themes you would like to see.
+        </p>
+      </section>
+
+      <section>
+        <ul class="feature-list">
+          <li>Progressive difficulty that adapts to the player's comfort level.</li>
+          <li>Visual cues that reinforce left-to-right spelling and blending.</li>
+          <li>Friendly characters cheering on every successful build.</li>
+        </ul>
+      </section>
+
+      <a class="button" href="../../index.html">Back to game selection</a>
+    </main>
+  </body>
+</html>

--- a/games/index.html
+++ b/games/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>All Games | Abe's Spelling Fun</title>
+    <link rel="stylesheet" href="../static-page.css" />
+    <style>
+      .grid {
+        display: grid;
+        gap: clamp(1rem, 2.2vw, 1.5rem);
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      }
+
+      .card {
+        text-decoration: none;
+        background: linear-gradient(160deg, rgba(255, 191, 250, 0.6), rgba(188, 159, 255, 0.7));
+        border-radius: 22px;
+        padding: 1.25rem;
+        color: rgba(51, 27, 64, 0.88);
+        font-weight: 600;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 18px 40px rgba(159, 103, 194, 0.22);
+        transition: transform 160ms ease, box-shadow 160ms ease;
+        display: flex;
+        flex-direction: column;
+        gap: 0.45rem;
+      }
+
+      .card:hover,
+      .card:focus-visible {
+        transform: translateY(-4px);
+        box-shadow: 0 22px 46px rgba(123, 76, 164, 0.26);
+        outline: none;
+      }
+
+      .card strong {
+        font-size: 1.2rem;
+        color: #3a1650;
+      }
+
+      .card span {
+        font-size: 0.95rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Explore Every Game</h1>
+        <p>Select a prototype below to learn more about each activity in the Abe's Spelling Fun collection.</p>
+      </header>
+
+      <div class="grid">
+        <a class="card" href="./animal-box/">
+          <strong>Animal Box</strong>
+          <span>Match animals with their sounds to strengthen phonemic awareness.</span>
+        </a>
+        <a class="card" href="./block-builder/">
+          <strong>Block Builder</strong>
+          <span>Arrange letter blocks into complete words and patterns.</span>
+        </a>
+        <a class="card" href="./basketball/">
+          <strong>Basketball Spelling</strong>
+          <span>Score points by typing each target word correctly.</span>
+        </a>
+        <a class="card" href="./block-breaker/">
+          <strong>Block Breaker</strong>
+          <span>Coming soon! Fast-paced spelling practice in an arcade format.</span>
+        </a>
+      </div>
+
+      <a class="button" href="../index.html">Back to home</a>
+    </main>
+  </body>
+</html>

--- a/settings/index.html
+++ b/settings/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Settings | Abe's Spelling Fun</title>
+    <link rel="stylesheet" href="../static-page.css" />
+    <style>
+      form {
+        display: grid;
+        gap: 1.1rem;
+      }
+
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        text-align: left;
+        font-weight: 600;
+        color: #3a1650;
+      }
+
+      input,
+      select {
+        border: 1px solid rgba(74, 33, 91, 0.25);
+        border-radius: 12px;
+        padding: 0.65rem 0.85rem;
+        font-size: 1rem;
+        font-family: inherit;
+      }
+
+      small {
+        font-weight: 400;
+        font-size: 0.85rem;
+        color: rgba(74, 33, 91, 0.7);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Settings Preview</h1>
+        <p>Customize how Abe's Spelling Fun will look and sound once the full application ships.</p>
+      </header>
+
+      <section>
+        <p>
+          These controls are a visual mock-up. They demonstrate the options families and teachers will have in
+          the upcoming release, including sound, difficulty, and accessibility preferences.
+        </p>
+      </section>
+
+      <form>
+        <label>
+          Display name
+          <input type="text" placeholder="Player name" disabled value="Abe" />
+          <small>Profiles will keep track of achievements and favorite games.</small>
+        </label>
+
+        <label>
+          Skill focus
+          <select disabled>
+            <option>Letter sounds</option>
+            <option>Spelling patterns</option>
+            <option>Vocabulary</option>
+          </select>
+          <small>Choose which skills to prioritize in daily practice.</small>
+        </label>
+
+        <label>
+          Audio volume
+          <input type="range" min="0" max="100" value="70" disabled />
+          <small>Adjust narration and sound effects for your environment.</small>
+        </label>
+      </form>
+
+      <a class="button" href="../index.html">Back to home</a>
+    </main>
+  </body>
+</html>

--- a/static-page.css
+++ b/static-page.css
@@ -1,0 +1,99 @@
+:root {
+  color-scheme: light;
+  font-family: 'Nunito', 'Segoe UI', Tahoma, sans-serif;
+  background: radial-gradient(circle at top, #ffe3ec, #f8f9ff);
+  color: #1b1b2f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+main {
+  width: min(960px, 100%);
+  background: rgba(255, 255, 255, 0.88);
+  backdrop-filter: blur(18px);
+  border-radius: 28px;
+  box-shadow: 0 30px 70px rgba(177, 125, 196, 0.28);
+  padding: clamp(1.5rem, 4vw, 2.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 2.25rem);
+}
+
+header {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+h1 {
+  margin: 0;
+  color: #4a215b;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  letter-spacing: 0.01em;
+}
+
+p {
+  margin: 0;
+  color: rgba(74, 33, 91, 0.82);
+  font-size: clamp(1rem, 2.2vw, 1.15rem);
+  line-height: 1.6;
+}
+
+section {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.85rem, 2.2vw, 1.35rem);
+}
+
+a.button {
+  align-self: center;
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.75rem 1.3rem;
+  border-radius: 999px;
+  background: rgba(74, 33, 91, 0.16);
+  color: #3a1650;
+  transition: background 140ms ease, transform 140ms ease;
+}
+
+a.button:hover,
+a.button:focus-visible {
+  background: rgba(74, 33, 91, 0.24);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+ul.feature-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+ul.feature-list li {
+  background: linear-gradient(150deg, rgba(255, 191, 250, 0.45), rgba(188, 159, 255, 0.55));
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  color: rgba(51, 27, 64, 0.86);
+  font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared static styling so linked prototype pages inherit the homepage look and feel
- create placeholder pages for each game route so the buttons resolve instead of returning 404s
- add an interim settings preview page and a games index to round out the navigation

## Testing
- not run (static HTML only)

------
https://chatgpt.com/codex/tasks/task_e_68dc0f823af0832198d0a21382992d8b