### PR TITLE
Add Green Light Squad to static launcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,11 @@
           <span>Match animals with their sounds and build vocabulary.</span>
         </a>
 
+        <a class="static-launcher__card" href="./games/green-light-squad/">
+          <strong>Green Light Squad</strong>
+          <span>Clear traffic with each correct letter—trigger green waves for big streaks!</span>
+        </a>
+
         <a class="static-launcher__card" href="./games/block-builder/">
           <strong>Block Builder</strong>
           <span>Construct words brick-by-brick to reinforce letter order.</span>


### PR DESCRIPTION
## Summary
- add the Green Light Squad option to the static launcher on the index page so it is selectable before the app loads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1c83d2e88321b33493f2fc73cbba