### PR TITLE
Add static Green Light Squad landing page

### DIFF
--- a/games/green-light-squad/index.html
+++ b/games/green-light-squad/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Green Light Squad | Abe's Spelling Fun</title>
+    <link rel="stylesheet" href="../../static-page.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Green Light Squad</h1>
+        <p>Keep the city moving by typing each letter correctly and triggering green light chains.</p>
+      </header>
+
+      <section>
+        <p>
+          Green Light Squad is one of the fast-paced spelling adventures in Abe's Spelling Fun. The full Phaser
+          prototype loads here in the production build so young drivers can clear traffic jams with flawless typing.
+        </p>
+        <p>
+          While development is underway, this placeholder page gives you a quick summary of the game loop and links you
+          back to the full collection of literacy activities.
+        </p>
+      </section>
+
+      <section>
+        <ul class="feature-list">
+          <li>Type letters in rhythm to wave through cars and build momentum.</li>
+          <li>Earn streak bonuses with perfect spelling to trigger city-wide green lights.</li>
+          <li>Approachable difficulty curve that ramps up as confidence grows.</li>
+        </ul>
+      </section>
+
+      <a class="button" href="../../index.html">Back to game selection</a>
+    </main>
+  </body>
+</html>

--- a/games/index.html
+++ b/games/index.html
@@ -55,6 +55,10 @@
           <strong>Animal Box</strong>
           <span>Match animals with their sounds to strengthen phonemic awareness.</span>
         </a>
+        <a class="card" href="./green-light-squad/">
+          <strong>Green Light Squad</strong>
+          <span>Trigger cascading green lights by spelling each prompt without mistakes.</span>
+        </a>
         <a class="card" href="./block-builder/">
           <strong>Block Builder</strong>
           <span>Arrange letter blocks into complete words and patterns.</span>

--- a/index.html
+++ b/index.html
@@ -180,6 +180,11 @@
           <span>Match animals with their sounds and build vocabulary.</span>
         </a>
 
+        <a class="static-launcher__card" href="./games/green-light-squad/">
+          <strong>Green Light Squad</strong>
+          <span>Clear traffic with each correct letter—trigger green waves for big streaks!</span>
+        </a>
+
         <a class="static-launcher__card" href="./games/block-builder/">
           <strong>Block Builder</strong>
           <span>Construct words brick-by-brick to reinforce letter order.</span>


### PR DESCRIPTION
## Summary
- add a static landing page for the Green Light Squad prototype so the link resolves correctly
- include the Green Light Squad card in the games directory listing for consistency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc1c83d2e88321b33493f2fc73cbba