### PR TITLE
chore: GitHub Pages deploy (Vite base, HashRouter, Actions)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -175,36 +175,36 @@
       </header>
 
       <div class="static-launcher__grid">
-        <a class="static-launcher__card" href="./games/animal-box/">
+        <a class="static-launcher__card" href="#/games/animal-box">
           <strong>Animal Box</strong>
           <span>Match animals with their sounds and build vocabulary.</span>
         </a>
 
-        <a class="static-launcher__card" href="./games/green-light-squad/">
+        <a class="static-launcher__card" href="#/games/green-light-squad">
           <strong>Green Light Squad</strong>
           <span>Clear traffic with each correct letter—trigger green waves for big streaks!</span>
         </a>
 
-        <a class="static-launcher__card" href="./games/block-builder/">
+        <a class="static-launcher__card" href="#/games/block-builder">
           <strong>Block Builder</strong>
           <span>Construct words brick-by-brick to reinforce letter order.</span>
         </a>
 
-        <a class="static-launcher__card" href="./games/basketball/">
+        <a class="static-launcher__card" href="#/games/basketball">
           <strong>Basketball</strong>
           <span>Shoot hoops by spelling each challenge word correctly.</span>
         </a>
 
-        <a class="static-launcher__card" href="./games/block-breaker/">
+        <a class="static-launcher__card" href="#/games/block-breaker">
           <strong>Block Breaker</strong>
           <span>Coming soon! Sharpen reflexes while spelling on the fly.</span>
         </a>
       </div>
 
       <nav class="static-launcher__links" aria-label="Quick links">
-        <a href="./">Home</a>
-        <a href="./games/">All games</a>
-        <a href="./settings/">Settings</a>
+        <a href="#/">Home</a>
+        <a href="#/games">All games</a>
+        <a href="#/settings">Settings</a>
       </nav>
     </section>
 

--- a/src/core/sfx.ts
+++ b/src/core/sfx.ts
@@ -1,10 +1,19 @@
 const sounds: Record<string, HTMLAudioElement> = {};
 
+const baseFromEnv =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.BASE_URL) || '/';
+const basePrefix = baseFromEnv.endsWith('/') ? baseFromEnv : `${baseFromEnv}/`;
+
+function withBase(path: string) {
+  const normalized = path.replace(/^\/+/, '');
+  return `${basePrefix}${normalized}`;
+}
+
 const SOUND_FILES = {
-  buzzer: '/assets/sfx/buzzer.mp3',
-  confetti: '/assets/sfx/confetti.mp3',
-  pop: '/assets/sfx/pop.mp3',
-  swish: '/assets/sfx/swish.mp3'
+  buzzer: withBase('assets/sfx/buzzer.mp3'),
+  confetti: withBase('assets/sfx/confetti.mp3'),
+  pop: withBase('assets/sfx/pop.mp3'),
+  swish: withBase('assets/sfx/swish.mp3')
 };
 
 function loadSound(key: keyof typeof SOUND_FILES) {


### PR DESCRIPTION
## Summary
- convert the custom router to use hash-based navigation so GitHub Pages can serve deep links without 404s
- point the static launcher links and audio asset URLs at hash/base-aware paths under /AbesSpellingFun/
- add a GitHub Actions workflow that builds the Vite project and uploads dist/ to GitHub Pages on every push to main

## Testing
- npm run build

## Follow-up
- In Settings → Pages ensure the Source is set to GitHub Actions if it isn’t already
- Expected URLs once deployed:
  - Home: https://arkist5.github.io/AbesSpellingFun/
  - Example game: https://arkist5.github.io/AbesSpellingFun/#/games/green-light-squad

------
https://chatgpt.com/codex/tasks/task_e_68dc33acba60832196851456e83b6907