### PR TITLE
Ensure landing nav uses hash route for games link

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
 
       <nav class="static-launcher__links" aria-label="Quick links">
         <a href="#/">Home</a>
-        <a href="#/games">All games</a>
+        <a href="#/games/">All games</a>
         <a href="#/settings">Settings</a>
       </nav>
     </section>


### PR DESCRIPTION
## Summary
- update the "All games" quick link on the landing page to use a hash-based route that works on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc94d007b88321bdcbb9319098efc5