### PR TITLE
Fix landing navigation hash link

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
 
       <nav class="static-launcher__links" aria-label="Quick links">
         <a href="#/">Home</a>
-        <a href="#/games/">All games</a>
+        <a href="#/games">All games</a>
         <a href="#/settings">Settings</a>
       </nav>
     </section>


### PR DESCRIPTION
## Summary
- update the landing page "All games" button to link to the hash-based route for compatibility with GitHub Pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd2637bc2c8321abe870be823ed62d